### PR TITLE
support for getting screen size on VM

### DIFF
--- a/xpywm
+++ b/xpywm
@@ -356,7 +356,7 @@ class WindowManager():
         width, height = self.screen.width_in_pixels, self.screen.height_in_pixels
         output = subprocess.getoutput('xrandr --current')
         # pick the last line including DP- or HDMI-
-        m = re.search(r'(DP-?\d|HDMI-?\d) connected (\d+)x(\d+)', output)
+        m = re.search(r'(Virtual-?\d|DP-?\d|HDMI-?\d) connected (?:primary )?(\d+)x(\d+)', output)
         if m:
             width, height = int(m.group(2)), int(m.group(3))
         # limit the screen size if sendscreen/record-desktop is running

--- a/xpywm
+++ b/xpywm
@@ -27,6 +27,7 @@ import sys
 import time
 
 from Xlib import X, display, XK
+from Xlib.error import XError
 
 FRAME_WIDTH = 2
 FRAME_COLOR = 'aquamarine1'
@@ -349,16 +350,27 @@ class WindowManager():
         return '0x{:x} [{}]'.format(window.id, self.get_window_class(window))
 
     def get_screen_size(self):
-        """Return the dimension (WIDTH, HEIGHT) of the current screen as a
-        tuple in pixels.  If xrandr command exsits and either DP (DisplayPort)
-        or HDMI output is active, return its dimensionn instead of the screen
-        size of the current X11 display."""
-        width, height = self.screen.width_in_pixels, self.screen.height_in_pixels
-        output = subprocess.getoutput('xrandr --current')
-        # pick the last line including DP- or HDMI-
-        m = re.search(r'(Virtual-?\d|DP-?\d|HDMI-?\d) connected (?:primary )?(\d+)x(\d+)', output)
-        if m:
-            width, height = int(m.group(2)), int(m.group(3))
+        resources = self.screen.root.xrandr_get_screen_resources()
+
+        def is_connected(outputid):
+            outinfo = self.display.xrandr_get_output_info(
+                outputid, resources.timestamp)._data
+            # connection: 1->connected, connection: 0-> unconnected
+            return not (outinfo['connection'])
+
+        width, height = None, None
+        for crtcid in reversed(resources._data['crtcs']):
+            # reverse to sort as subs -> primary...
+            try:
+                crtcinfo = self.display.xrandr_get_crtc_info(
+                    crtcid, resources.timestamp)._data
+                output = crtcinfo['outputs'][0]
+            except (XError, IndexError):
+                # Xlib.error.XError -> output is not displayed...maybe
+                # IndexError -> there is no output
+                continue
+            if is_connected(output):
+                width, height = crtcinfo['width'], crtcinfo['height']
         # limit the screen size if sendscreen/record-desktop is running
         code, output = subprocess.getstatusoutput('pidof -x sendscreen')
         if code == 0:


### PR DESCRIPTION
added support for getting screen size on VM.

xpywm got current screen size from output devices, HDMI or DP.
However, virtual machine does not use them so xpywm couldn't get screen size on VM.

ref: the result of xrandr on my environment (Windows10 / Virtual Box 6.1 / Debian 10.3)
$ xrandr
Screen 0: minimum 1 x 1, current 1440 x 900, maximum 8192 x 8192
Virtual1 connected primary 1440x900+0+0 (normal left inverted right x axis y axis) 0mm x 0mm
   800x600       60.00 +  60.32  
   2560x1600     59.99  
   1920x1440     60.00  
   1856x1392     60.00  
   1792x1344     60.00  
   1920x1200     59.88  
   1600x1200     60.00  
   1680x1050     59.95  
   1400x1050     59.98  
   1280x1024     60.02  
   1440x900      59.89* 
   1280x960      60.00  
   1360x768      60.02  
   1280x800      59.81  
   1152x864      75.00  
   1280x768      59.87  
   1024x768      60.00  
   640x480       59.94  
Virtual2 disconnected (normal left inverted right x axis y axis)
Virtual3 disconnected (normal left inverted right x axis y axis)
Virtual4 disconnected (normal left inverted right x axis y axis)
Virtual5 disconnected (normal left inverted right x axis y axis)
Virtual6 disconnected (normal left inverted right x axis y axis)
Virtual7 disconnected (normal left inverted right x axis y axis)
Virtual8 disconnected (normal left inverted right x axis y axis)
